### PR TITLE
Ajustes no método zip_search

### DIFF
--- a/br_crm_zip/models/crm_lead.py
+++ b/br_crm_zip/models/crm_lead.py
@@ -3,8 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models, api
-from odoo.tools.translate import _
-from odoo.exceptions import Warning
 
 
 class CrmLead(models.Model):
@@ -14,37 +12,10 @@ class CrmLead(models.Model):
     @api.multi
     def zip_search(self):
         self.ensure_one()
-        obj_zip = self.env['br.zip']
-
-        zip_ids = obj_zip.zip_search_multi(
-            country_id=self.country_id.id,
-            state_id=self.state_id.id,
-            city_id=self.city_id.id,
-            district=self.district,
-            street=self.street,
-            zip_code=self.zip,
-        )
-
-        if len(zip_ids) == 1:
-            result = obj_zip.set_result(zip_ids[0])
-            self.write(result)
-            return True
-        else:
-            if len(zip_ids) > 1:
-                obj_zip_result = self.env['br.zip.result']
-                zip_ids = obj_zip_result.map_to_zip_result(
-                    zip_ids, self._name, self.id)
-
-                return obj_zip.create_wizard(
-                    self._name,
-                    self.id,
-                    country_id=self.country_id.id,
-                    state_id=self.state_id.id,
-                    city_id=self.city_id.id,
-                    district=self.district,
-                    street=self.street,
-                    zip_code=self.zip,
-                    zip_ids=[z.id for z in zip_ids],
-                )
-            else:
-                raise Warning(_('Nenhum registro encontrado'))
+        res = self.env['br.zip'].zip_search(country_id=self.country_id.id,
+                                            state_id=self.state_id.id,
+                                            city_id=self.city_id.id,
+                                            district=self.district,
+                                            street=self.street,
+                                            zip_code=self.zip)
+        self.update(res)

--- a/br_crm_zip/models/crm_lead.py
+++ b/br_crm_zip/models/crm_lead.py
@@ -18,4 +18,6 @@ class CrmLead(models.Model):
                                             district=self.district,
                                             street=self.street,
                                             zip_code=self.zip)
-        self.update(res)
+        if 'zip' in res:
+            self.update(res)
+        return res

--- a/br_crm_zip/models/crm_lead.py
+++ b/br_crm_zip/models/crm_lead.py
@@ -12,12 +12,11 @@ class CrmLead(models.Model):
     @api.multi
     def zip_search(self):
         self.ensure_one()
-        res = self.env['br.zip'].zip_search(country_id=self.country_id.id,
+        res = self.env['br.zip'].zip_search(obj_name=self,
+                                            country_id=self.country_id.id,
                                             state_id=self.state_id.id,
                                             city_id=self.city_id.id,
                                             district=self.district,
                                             street=self.street,
                                             zip_code=self.zip)
-        if 'zip' in res:
-            self.update(res)
         return res

--- a/br_zip/models/br_zip.py
+++ b/br_zip/models/br_zip.py
@@ -150,7 +150,7 @@ class BrZip(models.Model):
             _logger.error(e.message, exc_info=True)
 
     @api.multi
-    def zip_search(self, country_id=False, state_id=False,
+    def zip_search(self, obj_name, country_id=False, state_id=False,
                    city_id=False, district=False,
                    street=False, zip_code=False):
 
@@ -160,22 +160,24 @@ class BrZip(models.Model):
             street, zip_code)
 
         if len(zip_ids) == 1:
-            return self.set_result(zip_ids[0])
+            res = self.set_result(zip_ids[0])
+            obj_name.update(res)
+            return True
         else:
             if len(zip_ids) > 1:
                 obj_zip_result = self.env['br.zip.result']
                 zip_ids = obj_zip_result.map_to_zip_result(
-                    zip_ids, self._name, self.id)
+                    zip_ids, obj_name._name, obj_name.id)
 
                 return self.create_wizard(
-                    self._name,
-                    self.id,
-                    country_id=self.country_id.id,
-                    state_id=self.state_id.id,
-                    city_id=self.city_id.id,
-                    district=self.district,
-                    street=self.street,
-                    zip_code=self.zip,
+                    obj_name._name,
+                    obj_name.id,
+                    country_id=obj_name.country_id.id,
+                    state_id=obj_name.state_id.id,
+                    city_id=obj_name.city_id.id,
+                    district=obj_name.district,
+                    street=obj_name.street,
+                    zip_code=obj_name.zip,
                     zip_ids=[z.id for z in zip_ids]
                 )
             else:

--- a/br_zip/models/res_bank.py
+++ b/br_zip/models/res_bank.py
@@ -19,4 +19,4 @@ class ResBank(models.Model):
                                             district=self.district,
                                             street=self.street,
                                             zip_code=self.zip)
-        self.update(res)
+        return res

--- a/br_zip/models/res_bank.py
+++ b/br_zip/models/res_bank.py
@@ -7,13 +7,13 @@ from odoo import api, models
 
 
 class ResBank(models.Model):
-
     _inherit = 'res.bank'
 
     @api.multi
     def zip_search(self):
         self.ensure_one()
-        res = self.env['br.zip'].zip_search(country_id=self.country_id.id,
+        res = self.env['br.zip'].zip_search(obj_name=self,
+                                            country_id=self.country_id.id,
                                             state_id=self.state_id.id,
                                             city_id=self.city_id.id,
                                             district=self.district,

--- a/br_zip/models/res_bank.py
+++ b/br_zip/models/res_bank.py
@@ -9,6 +9,11 @@ from odoo import api, models
 class ResBank(models.Model):
     _inherit = 'res.bank'
 
+    @api.onchange('zip')
+    def _onchange_field(self):
+        if self.zip and len(self.zip.replace('-', '')) == 8:
+            self.zip_search()
+
     @api.multi
     def zip_search(self):
         self.ensure_one()

--- a/br_zip/models/res_company.py
+++ b/br_zip/models/res_company.py
@@ -13,12 +13,11 @@ class ResCompany(models.Model):
     @api.multi
     def zip_search(self):
         self.ensure_one()
-        res = self.env['br.zip'].zip_search(country_id=self.country_id.id,
+        res = self.env['br.zip'].zip_search(obj_name=self,
+                                            country_id=self.country_id.id,
                                             state_id=self.state_id.id,
                                             city_id=self.city_id.id,
                                             district=self.district,
                                             street=self.street,
                                             zip_code=self.zip)
-        if 'zip' in res:
-            self.update(res)
         return res

--- a/br_zip/models/res_company.py
+++ b/br_zip/models/res_company.py
@@ -19,4 +19,6 @@ class ResCompany(models.Model):
                                             district=self.district,
                                             street=self.street,
                                             zip_code=self.zip)
-        self.update(res)
+        if 'zip' in res:
+            self.update(res)
+        return res

--- a/br_zip/models/res_company.py
+++ b/br_zip/models/res_company.py
@@ -12,4 +12,11 @@ class ResCompany(models.Model):
 
     @api.multi
     def zip_search(self):
-        return self.partner_id.zip_search()
+        self.ensure_one()
+        res = self.env['br.zip'].zip_search(country_id=self.country_id.id,
+                                            state_id=self.state_id.id,
+                                            city_id=self.city_id.id,
+                                            district=self.district,
+                                            street=self.street,
+                                            zip_code=self.zip)
+        self.update(res)

--- a/br_zip/models/res_company.py
+++ b/br_zip/models/res_company.py
@@ -10,6 +10,11 @@ from odoo import models, api
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
+    @api.onchange('zip')
+    def _onchange_field(self):
+        if self.zip and len(self.zip.replace('-', '')) == 8:
+            self.zip_search()
+
     @api.multi
     def zip_search(self):
         self.ensure_one()

--- a/br_zip/models/res_partner.py
+++ b/br_zip/models/res_partner.py
@@ -24,4 +24,6 @@ class ResPartner(models.Model):
                                             district=self.district,
                                             street=self.street,
                                             zip_code=self.zip)
-        self.update(res)
+        if 'zip' in res:
+            self.update(res)
+        return res

--- a/br_zip/models/res_partner.py
+++ b/br_zip/models/res_partner.py
@@ -18,12 +18,11 @@ class ResPartner(models.Model):
     @api.multi
     def zip_search(self):
         self.ensure_one()
-        res = self.env['br.zip'].zip_search(country_id=self.country_id.id,
+        res = self.env['br.zip'].zip_search(obj_name=self,
+                                            country_id=self.country_id.id,
                                             state_id=self.state_id.id,
                                             city_id=self.city_id.id,
                                             district=self.district,
                                             street=self.street,
                                             zip_code=self.zip)
-        if 'zip' in res:
-            self.update(res)
         return res

--- a/br_zip/models/res_partner.py
+++ b/br_zip/models/res_partner.py
@@ -5,14 +5,12 @@
 
 
 from odoo import models, api
-from odoo.tools.translate import _
-from odoo.exceptions import UserError
 
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    @api.onchange("zip")
+    @api.onchange('zip')
     def _onchange_field(self):
         if self.type != 'contact':
             self.zip_search()
@@ -20,37 +18,10 @@ class ResPartner(models.Model):
     @api.multi
     def zip_search(self):
         self.ensure_one()
-        obj_zip = self.env['br.zip']
-
-        zip_ids = obj_zip.zip_search_multi(
-            country_id=self.country_id.id,
-            state_id=self.state_id.id,
-            city_id=self.city_id.id,
-            district=self.district,
-            street=self.street,
-            zip_code=self.zip,
-        )
-
-        if len(zip_ids) == 1:
-            result = obj_zip.set_result(zip_ids[0])
-            self.update(result)
-            return True
-        else:
-            if len(zip_ids) > 1:
-                obj_zip_result = self.env['br.zip.result']
-                zip_ids = obj_zip_result.map_to_zip_result(
-                    zip_ids, self._name, self.id)
-
-                return obj_zip.create_wizard(
-                    self._name,
-                    self.id,
-                    country_id=self.country_id.id,
-                    state_id=self.state_id.id,
-                    city_id=self.city_id.id,
-                    district=self.district,
-                    street=self.street,
-                    zip_code=self.zip,
-                    zip_ids=[zip.id for zip in zip_ids]
-                )
-            else:
-                raise UserError(_('Nenhum registro encontrado'))
+        res = self.env['br.zip'].zip_search(country_id=self.country_id.id,
+                                            state_id=self.state_id.id,
+                                            city_id=self.city_id.id,
+                                            district=self.district,
+                                            street=self.street,
+                                            zip_code=self.zip)
+        self.update(res)

--- a/br_zip/models/res_partner.py
+++ b/br_zip/models/res_partner.py
@@ -12,7 +12,7 @@ class ResPartner(models.Model):
 
     @api.onchange('zip')
     def _onchange_field(self):
-        if self.type != 'contact':
+        if self.zip and len(self.zip.replace('-', '')) == 8:
             self.zip_search()
 
     @api.multi

--- a/br_zip/views/res_bank_view.xml
+++ b/br_zip/views/res_bank_view.xml
@@ -8,7 +8,7 @@
         <field name="priority">33</field>
         <field name="arch" type="xml">
             <field name="zip" position="after">
-                <button name="zip_search" type="object" class="oe_inline">
+                <button name="zip_search" type="object" class="oe_inline" invisible="1">
                     <i class="fa fa-search"></i>
                 </button>
             </field>

--- a/br_zip/views/res_company_view.xml
+++ b/br_zip/views/res_company_view.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="br_base.view_company_form_inherited"/>
         <field name="arch" type="xml">
             <field name="zip" position="after">
-                <button name="zip_search" type="object" class="oe_inline">
+                <button name="zip_search" type="object" class="oe_inline" invisible="1">
                     <i class="fa fa-search"></i>
                 </button>
             </field>

--- a/br_zip/views/res_partner_view.xml
+++ b/br_zip/views/res_partner_view.xml
@@ -8,7 +8,7 @@
         <field name="priority">33</field>
         <field name="arch" type="xml">
             <field name="zip" position="after">
-                <button name="zip_search" type="object" class="oe_inline">
+                <button name="zip_search" type="object" class="oe_inline" invisible="1">
                     <i class="fa fa-search"></i>
                 </button>
             </field>

--- a/br_zip/wizard/br_zip_search.py
+++ b/br_zip/wizard/br_zip_search.py
@@ -84,7 +84,7 @@ class BrZipSearch(models.TransientModel):
 
         return {
             'type': 'ir.actions.act_window',
-            'res_model': 'l10n_br.zip.search',
+            'res_model': 'br.zip.search',
             'view_mode': 'form',
             'view_type': 'form',
             'res_id': self.id,

--- a/br_zip/wizard/br_zip_search.py
+++ b/br_zip/wizard/br_zip_search.py
@@ -13,26 +13,23 @@ class BrZipSearch(models.TransientModel):
     zip = fields.Char('CEP', size=8)
     street = fields.Char('Logradouro', size=72)
     district = fields.Char('Bairro', size=72)
-    country_id = fields.Many2one('res.country', 'Country')
-    state_id = fields.Many2one(
-        "res.country.state", 'Estado',
-        domain="[('country_id','=',country_id)]")
-    city_id = fields.Many2one(
-        'res.state.city', 'Cidade',
-        domain="[('state_id','=',state_id)]")
-    zip_ids = fields.Many2many(
-        'br.zip.result', 'zip_search', 'zip_search_id',
-        'zip_id', 'CEP', readonly=False)
-    state = fields.Selection(
-        [('init', 'init'), ('done', 'done')],
-        'state', readonly=True, default='init')
-    address_id = fields.Integer('Id do objeto', invisible=True)
-    object_name = fields.Char('Nome do bjeto', size=100, invisible=True)
+    country_id = fields.Many2one('res.country', u'País')
+    state_id = fields.Many2one("res.country.state", 'Estado',
+                               domain="[('country_id','=',country_id)]")
+    city_id = fields.Many2one('res.state.city', 'Cidade',
+                              domain="[('state_id','=',state_id)]")
+    zip_ids = fields.Many2many('br.zip.result', 'zip_search', 'zip_search_id',
+                               'zip_id', 'CEP', readonly=False)
+    state = fields.Selection([('init', 'init'),
+                              ('done', 'done')],
+                             u'Situação', readonly=True, default='init')
+    address_id = fields.Integer('Id do Objeto', invisible=True)
+    object_name = fields.Char('Nome do Objeto', size=100, invisible=True)
 
     @api.model
-    def default_get(self, fields):
+    def default_get(self, fields_values):
         data = super(BrZipSearch, self).default_get(
-            fields)
+            fields_values)
         context = self._context
         data['zip'] = context.get('zip', False)
         data['street'] = context.get('street', False)
@@ -42,13 +39,13 @@ class BrZipSearch(models.TransientModel):
         data['city_id'] = context.get('city_id', False)
         data['address_id'] = context.get('address_id', False)
         data['object_name'] = context.get('object_name', False)
-
         data['zip_ids'] = context.get('zip_ids', False)
         data['state'] = 'done'
         return data
 
-    @api.one
+    @api.multi
     def zip_search(self):
+        self.ensure_one()
         data = self
         obj_zip = self.env['br.zip']
         obj_zip_result = self.env['br.zip.result']
@@ -102,23 +99,23 @@ class BrZipResult(models.TransientModel):
     _description = 'Zipcode result'
 
     zip_id = fields.Many2one(
-        'br.zip', 'Zipcode', readonly=True, invisible=True)
-    search_id = fields.Many2one(
-        'br.zip.search', 'Search', readonly=True, invisible=True)
-    address_id = fields.Integer('Id do objeto', invisible=True)
-    object_name = fields.Char('Nome do bjeto', size=100, invisible=True)
+        'br.zip', 'Zip Code', readonly=True, invisible=True)
+    search_id = fields.Many2one('br.zip.search', 'Busca', readonly=True,
+                                invisible=True)
+    address_id = fields.Integer('Id do Objeto', invisible=True)
+    object_name = fields.Char('Nome do Objeto', size=100, invisible=True)
     # ZIPCODE data to be shown
     zip = fields.Char('CEP', size=9, readonly=True)
     street = fields.Char('Logradouro', size=72, readonly=True)
     street_type = fields.Char('Tipo', size=26, readonly=True)
     district = fields.Char('Bairro', size=72, readonly=True)
-    country_id = fields.Many2one('res.country', 'Country', readonly=True)
+    country_id = fields.Many2one('res.country', u'País', readonly=True)
     state_id = fields.Many2one('res.country.state', 'Estado',
                                domain="[('country_id', '=', country_id)]",
                                readonly=True)
-    city_id = fields.Many2one(
-        'res.state.city', 'Cidade', required=True,
-        domain="[('state_id', '=', state_id)]", readonly=True)
+    city_id = fields.Many2one('res.state.city', 'Cidade', required=True,
+                              domain="[('state_id', '=', state_id)]",
+                              readonly=True)
 
     def map_to_zip_result(self, zip_data, object_name, address_id):
         obj_zip = self.env['br.zip']

--- a/br_zip/wizard/br_zip_search.py
+++ b/br_zip/wizard/br_zip_search.py
@@ -131,8 +131,9 @@ class BrZipResult(models.TransientModel):
             result.append(zip_result_id)
         return result
 
-    @api.one
+    @api.multi
     def zip_select(self):
+        self.ensure_one()
         data = self
         address_id = data['address_id']
         object_name = data['object_name']

--- a/br_zip/wizard/br_zip_search_view.xml
+++ b/br_zip/wizard/br_zip_search_view.xml
@@ -51,12 +51,14 @@
         <field name="model">br.zip.result</field>
         <field name="arch" type="xml">
             <form string="CEPs">
-                <field name="zip" select="1"/>
-                <field name="street" select="1"/>
-                <field name="district" select="2"/>
-                <field name="country_id" select="2"/>
-                <field name="state_id" select="2"/>
-                <field name="city_id" select="2"/>
+                <group>
+                    <field name="zip" select="1"/>
+                    <field name="street" select="1"/>
+                    <field name="district" select="2"/>
+                    <field name="country_id" select="2"/>
+                    <field name="state_id" select="2"/>
+                    <field name="city_id" select="2"/>
+                </group>
             </form>
         </field>
     </record>

--- a/br_zip/wizard/br_zip_search_view.xml
+++ b/br_zip/wizard/br_zip_search_view.xml
@@ -38,7 +38,7 @@
         <field name="model">br.zip.result</field>
         <field name="arch" type="xml">
             <tree string="CEPs">
-                <button name="zip_select" string="Selecionar" type="object" icon="gtk-apply"/>
+                <button name="zip_select" string="Selecionar" type="object" icon="fa fa-check"/>
                 <field name="zip" select="1"/>
                 <field name="district" select="1"/>
                 <field name="street" select="1"/>


### PR DESCRIPTION
* Refatoração do método `zip_search` de *res_partner* de modo a torná-lo menos desacoplado. O processo foi realizado nos módulos `br_zip`  e `br_crm_zip`
* Finalização da migração do módulo `br_zip` para Odoo api 10 (alguns *imports* não haviam sido migrados)
* Correção da view que mostra os dados do endereço quando realizamos a busca por logradouro. Ao clicarmos em um dos resultados da pesquisa, os campos do endereço eram exibidos na mesma linha.

![captura de tela de 2016-12-02 10-41-15](https://cloud.githubusercontent.com/assets/8174740/20834857/8d69f88c-b87e-11e6-9182-71628e2af30a.png)

* Corrigido ícone do botão "selecionar " quando realizamos a busca por logradouro.

![captura de tela de 2016-12-02 10-41-19](https://cloud.githubusercontent.com/assets/8174740/20834883/ab5ce1e2-b87e-11e6-90a8-37e58f2912dc.png)

* Correção do bug quando pressionamos o botão "Nova Pesquisa" na tela de pesquisa pelo logradouro (na tela da imagem acima).

![captura de tela de 2016-12-02 10-42-19](https://cloud.githubusercontent.com/assets/8174740/20834906/ca33d12a-b87e-11e6-812a-84658bd92755.png)

* Tradução de campos que estavam em inglês e ajustes na formatação do código


