### PR TITLE
Padronizacao dos campos de endereço da tela de cadastro de bancos

### DIFF
--- a/br_base/__manifest__.py
+++ b/br_base/__manifest__.py
@@ -24,6 +24,7 @@
         'views/br_base_view.xml',
         'views/res_country_view.xml',
         'views/res_partner_view.xml',
+        'views/res_bank_view.xml',
         'views/res_company_view.xml',
         'security/ir.model.access.csv',
     ],

--- a/br_base/models/__init__.py
+++ b/br_base/models/__init__.py
@@ -7,3 +7,4 @@ from . import br_base
 from . import res_company
 from . import res_country
 from . import res_partner
+from . import res_bank

--- a/br_base/models/res_bank.py
+++ b/br_base/models/res_bank.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# © 2016  Michell Stuttgart (MultidadosTI)
+# © 2016  Aldo Soares (MultidadosTI)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields, api
+
+
+class ResBank(models.Model):
+    _inherit = 'res.bank'
+
+    number = fields.Char(u'Número', size=10)
+    street2 = fields.Char('Complemento', size=128)
+    district = fields.Char('Bairro', size=32)
+    city_id = fields.Many2one(comodel_name='res.state.city',
+                              string=u'Município',
+                              domain="[('state_id','=',state_id)]")
+
+    country_id = fields.Many2one(comodel_name='res.country',
+                                 related='country',
+                                 string=u'País')
+    state_id = fields.Many2one(comodel_name='res.country.state',
+                               related='state',
+                               string='Estado')
+
+    @api.onchange('city_id')
+    def onchange_city_id(self):
+        """ Ao alterar o campo city_id copia o nome
+        do município para o campo city que é o campo nativo do módulo base
+        para manter a compatibilidade entre os demais módulos que usam o
+        campo city.
+        """
+        if self.city_id:
+            self.city = self.city_id.name
+
+
+class ResPartnerBank(models.Model):
+    """ Adiciona campos necessários para o cadastramentos de contas
+    bancárias no Brasil."""
+    _inherit = 'res.partner.bank'
+
+    acc_number = fields.Char('Account Number', size=64, required=False)
+    acc_number_dig = fields.Char(u'Digito Conta', size=8)
+    bra_number = fields.Char(u'Agência', size=8)
+    bra_number_dig = fields.Char(u'Dígito Agência', size=8)

--- a/br_base/models/res_partner.py
+++ b/br_base/models/res_partner.py
@@ -237,35 +237,3 @@ class ResPartner(models.Model):
                     raise UserError(msg)
         else:
             raise UserError(u'Preencha o estado e o CNPJ para pesquisar')
-
-
-class ResBank(models.Model):
-    _inherit = 'res.bank'
-
-    number = fields.Char(u'Número', size=10)
-    street2 = fields.Char('Street2', size=128)
-    district = fields.Char('Bairro', size=32)
-    city_id = fields.Many2one(comodel_name='res.state.city',
-                              string='Municipio',
-                              domain="[('state_id','=',state_id)]")
-
-    @api.onchange('city_id')
-    def onchange_city_id(self):
-        """ Ao alterar o campo city_id copia o nome
-        do município para o campo city que é o campo nativo do módulo base
-        para manter a compatibilidade entre os demais módulos que usam o
-        campo city.
-        """
-        if self.city_id:
-            self.city = self.city_id.name
-
-
-class ResPartnerBank(models.Model):
-    """ Adiciona campos necessários para o cadastramentos de contas
-    bancárias no Brasil."""
-    _inherit = 'res.partner.bank'
-
-    acc_number = fields.Char('Account Number', size=64, required=False)
-    acc_number_dig = fields.Char(u'Digito Conta', size=8)
-    bra_number = fields.Char(u'Agência', size=8)
-    bra_number_dig = fields.Char(u'Dígito Agência', size=8)

--- a/br_base/views/res_bank_view.xml
+++ b/br_base/views/res_bank_view.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_br_base_res_bank_form" model="ir.ui.view">
+        <field name="name">view_br_base.res.bank.form</field>
+        <field name="model">res.bank</field>
+        <field name="inherit_id" ref="base.view_res_bank_form" />
+        <field name="arch" type="xml">
+            <field name="street2" position="replace"/>
+               <field name="zip" position="replace"/>
+               <field name="street" position="replace">
+                   <field name="zip" placeholder="CEP" style="width:50%" />
+                   <field name="street" placeholder="Logradouro" />
+                   <field name="number" placeholder="Número"/>
+                   <field name="street2" placeholder="Complemento"/>
+                   <field name="district" placeholder="Bairro"/>
+                   <field name="country_id" placeholder="País"/>
+                   <field name="state_id" placeholder="Estado"/>
+                   <field name="city_id" placeholder="Cidade"/>
+               </field>
+               <field name="state_id" position="attributes">
+                   <attribute name="domain">[('country_id','=',country_id)]</attribute>
+                   <attribute name="style">width:100%</attribute>
+               </field>
+               <field name="country" position="replace">
+                   <field name="country" invisible="1"/>
+               </field>
+               <field name="state" position="replace">
+                   <field name="state" invisible="1"/>
+               </field>
+               <field name="city" position="replace">
+                   <field name="city" invisible="1"/>
+               </field>
+        </field>
+    </record>
+
+    <!-- res.partner.bank -->
+    <record id="view_br_base_partner_bank_form" model="ir.ui.view">
+        <field name="name">view_br_base.partner.bank.form</field>
+        <field name="model">res.partner.bank</field>
+        <field name="inherit_id" ref="base.view_partner_bank_form" />
+        <field name="arch" type="xml">
+            <field name="acc_number" position="replace">
+                <newline />
+                <field name="acc_number" select="1" />
+                <field name="acc_number_dig" select="1" />
+                <newline />
+                <field name="bra_number" select="1" />
+                <field name="bra_number_dig" select="1" />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_br_base_partner_bank_tree" model="ir.ui.view">
+        <field name="name">view_br_base.partner.bank.tree</field>
+        <field name="model">res.partner.bank</field>
+        <field name="inherit_id" ref="base.view_partner_bank_tree" />
+        <field name="arch" type="xml">
+            <field name="acc_number" position="replace">
+                <field name="acc_number" />
+                <field name="acc_number_dig" />
+                <field name="bra_number" />
+                <field name="bra_number_dig" />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/br_base/views/res_company_view.xml
+++ b/br_base/views/res_company_view.xml
@@ -14,7 +14,7 @@
             <field name="street2" position="replace"/>
             <field name="zip" position="replace"/>
             <field name="street" position="replace">
-                <field name="zip" placeholder="Cep" class="o_address_zip" />
+                <field name="zip" placeholder="CEP" class="o_address_zip" />
                 <field name="street" placeholder="Logradouro" class="o_address_street" />
                 <field name="number" placeholder="Número" class="o_address_city"/>
                 <field name="street2" placeholder="Complemento" class="o_address_street" />

--- a/br_base/views/res_partner_view.xml
+++ b/br_base/views/res_partner_view.xml
@@ -44,7 +44,7 @@
             </xpath>
             <field name="zip" position="replace" />
             <field name="street" position="replace">
-                <field name="zip" placeholder="Cep" class="o_address_zip oe_inline" />
+                <field name="zip" placeholder="CEP" class="o_address_zip oe_inline" />
                 <field name="street" class="o_address_street" placeholder="Logradouro" />
                 <field name="number" class="o_address_city" placeholder="Número" />
                 <field name="district" class="o_address_state" placeholder="Bairro" />
@@ -95,56 +95,6 @@
             <xpath expr="//div[@name='div_address']/field[@name='state_id']" potition="after">
                 <field name="city_id" placeholder="Município" />
             </xpath>
-        </field>
-    </record>
-
-    <!-- res.partner.bank -->
-    <record id="view_br_base_partner_bank_form" model="ir.ui.view">
-        <field name="name">view_br_base.partner.bank.form</field>
-        <field name="model">res.partner.bank</field>
-        <field name="inherit_id" ref="base.view_partner_bank_form" />
-        <field name="arch" type="xml">
-            <field name="acc_number" position="replace">
-                <newline />
-                <field name="acc_number" select="1" />
-                <field name="acc_number_dig" select="1" />
-                <newline />
-                <field name="bra_number" select="1" />
-                <field name="bra_number_dig" select="1" />
-            </field>
-        </field>
-    </record>
-
-
-    <record id="view_br_base_res_bank_form" model="ir.ui.view">
-        <field name="name">view_br_base.res.bank.form</field>
-        <field name="model">res.bank</field>
-        <field name="inherit_id" ref="base.view_res_bank_form" />
-        <field name="arch" type="xml">
-            <field name="street" position="after">
-                <field name="number" placeholder="Número..." />
-                <field name="district" placeholder="Bairro..." />
-            </field>
-            <field name="state" position="after">
-                <field name="city_id" placeholder="Cidade" />
-            </field>
-            <field name="city" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </field>
-        </field>
-    </record>
-
-    <record id="view_br_base_partner_bank_tree" model="ir.ui.view">
-        <field name="name">view_br_base.partner.bank.tree</field>
-        <field name="model">res.partner.bank</field>
-        <field name="inherit_id" ref="base.view_partner_bank_tree" />
-        <field name="arch" type="xml">
-            <field name="acc_number" position="replace">
-                <field name="acc_number" />
-                <field name="acc_number_dig" />
-                <field name="bra_number" />
-                <field name="bra_number_dig" />
-            </field>
         </field>
     </record>
 

--- a/br_zip/models/res_bank.py
+++ b/br_zip/models/res_bank.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-#
 #    Copyright (C) 2016 MultidadosTI (http://www.multidadosti.com.br)
 #    @author Michell Stuttgart <m.faria@itimpacta.org.br>
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html


### PR DESCRIPTION
Padronização na disposição dos campos de endereço da tela de cadastro de bancos.

@danimaribeiro a busca do CEP na tela de cadastro de bancos (7dfe93465779ebc15b296520da8a1ba0b3f448b9) depende deste PR para funcionar