### PR TITLE
[FIX] Tipo do produto não é sincronizado com Tipo Fiscal do Produto

### DIFF
--- a/br_account/models/product.py
+++ b/br_account/models/product.py
@@ -26,6 +26,10 @@ class ProductTemplate(models.Model):
     cest = fields.Char(string="CEST", size=10,
                        help=u"Código Especificador da Substituição Tributária")
 
-    @api.onchange('type', 'fiscal_type')
+    @api.onchange('type')
     def onchange_product_type(self):
         self.fiscal_type = 'service' if self.type == 'service' else 'product'
+
+    @api.onchange('fiscal_type')
+    def onchange_product_fiscal_type(self):
+        self.type = 'service' if self.fiscal_type == 'service' else 'consu'

--- a/br_account/models/product.py
+++ b/br_account/models/product.py
@@ -4,7 +4,7 @@
 # © 2016 Danimar Ribeiro, Trustcode
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields
+from odoo import models, fields, api
 from .cst import ORIGEM_PROD
 
 
@@ -25,3 +25,7 @@ class ProductTemplate(models.Model):
 
     cest = fields.Char(string="CEST", size=10,
                        help=u"Código Especificador da Substituição Tributária")
+
+    @api.onchange('type', 'fiscal_type')
+    def onchange_product_type(self):
+        self.fiscal_type = 'service' if self.type == 'service' else 'product'


### PR DESCRIPTION
Quando criamos um produto

> Vendas -> Produtos

O tipo de produto selecionado no campo "Tipo de Serviço" não estava sendo sincronizado com a opção escolhida no campo "Tipo Fiscal". Dessa maneira o usuário poderia selecionar um produto do tipo "consumível" e no campo "Tipo Fiscal" selecionar "Serviço", o que não faz sentido. Além disso o campo "Tipo Fiscal" precisa de permissão em contabilidade para ser setado, enquanto para o campo "Tipo do Produto" não requer permissão especial. Sendo assim gerando inconsistência na cadastro de produtos.

Deixei o "Tipo Fiscal" como *readonly* evitando assim que o usuário escolha um valor diferente para ele.

Agora, quando o usuário cadastrar um produto, ao inserir o "Tipo do Produto", o "Tipo Fiscal" já será automaticamente setado"
