### PR TITLE
Campo percentual de dedução usado no cálculo do ICMS ST do simples nacional

### DIFF
--- a/br_account/models/account_fiscal_position.py
+++ b/br_account/models/account_fiscal_position.py
@@ -53,6 +53,10 @@ class AccountFiscalPositionTaxRule(models.Model):
     reducao_icms_st = fields.Float(string=u"Redução de base ST")
     reducao_ipi = fields.Float(string=u"Redução de base IPI")
     aliquota_mva = fields.Float(string=u"Alíquota MVA")
+    icms_st_aliquota_deducao = fields.Float(
+        string=u"% Dedução", help="Alíquota interna ou interestadual aplicada \
+         sobre o valor da operação para deduzir do ICMS ST - Para empresas \
+         do Simples Nacional")
     tem_difal = fields.Boolean(string="Aplicar Difal?")
     tax_icms_inter_id = fields.Many2one(
         'account.tax', help=u"Alíquota utilizada na operação Interestadual",
@@ -133,6 +137,7 @@ class AccountFiscalPosition(models.Model):
                 'tax_icms_st_id': rules[0].tax_icms_st_id,
                 'icms_st_aliquota_mva': rules[0].aliquota_mva,
                 'icms_st_aliquota_reducao_base': rules[0].reducao_icms_st,
+                'icms_st_aliquota_deducao': rules[0].icms_st_aliquota_deducao,
                 # ICMS Difal
                 'tem_difal': rules[0].tem_difal,
                 'tax_icms_inter_id': rules[0].tax_icms_inter_id,

--- a/br_account/models/account_invoice_line.py
+++ b/br_account/models/account_invoice_line.py
@@ -31,6 +31,7 @@ class AccountInvoiceLine(models.Model):
             'icms_aliquota_reducao_base': self.icms_aliquota_reducao_base,
             'icms_st_aliquota_reducao_base':
             self.icms_st_aliquota_reducao_base,
+            'icms_st_aliquota_deducao': self.icms_st_aliquota_deducao,
             'ipi_reducao_bc': self.ipi_reducao_bc,
             'icms_base_calculo': self.icms_base_calculo,
             'ipi_base_calculo': self.ipi_base_calculo,
@@ -48,7 +49,8 @@ class AccountInvoiceLine(models.Model):
                  'tax_pis_id', 'tax_cofins_id', 'tax_ii_id', 'tax_issqn_id',
                  'incluir_ipi_base', 'tem_difal', 'icms_aliquota_reducao_base',
                  'ipi_reducao_bc', 'icms_st_aliquota_mva', 'tax_simples_id',
-                 'icms_st_aliquota_reducao_base')
+                 'icms_st_aliquota_reducao_base', 'icms_aliquota_credito',
+                 'icms_st_aliquota_deducao')
     def _compute_price(self):
         currency = self.invoice_id and self.invoice_id.currency_id or None
         price = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
@@ -265,6 +267,10 @@ class AccountInvoiceLine(models.Model):
     icms_aliquota_credito = fields.Float(u"% Cŕedito ICMS")
     icms_valor_credito = fields.Float(
         u"Valor de Crédito", compute='_compute_price')
+    icms_st_aliquota_deducao = fields.Float(
+        string=u"% Dedução", help="Alíquota interna ou interestadual aplicada \
+         sobre o valor da operação para deduzir do ICMS ST - Para empresas \
+         do Simples Nacional")
 
     # =========================================================================
     # ISSQN
@@ -462,60 +468,56 @@ class AccountInvoiceLine(models.Model):
     def _onchange_tax_icms_id(self):
         if self.tax_icms_id:
             self.icms_aliquota = self.tax_icms_id.amount
-            self._update_invoice_line_ids()
+        self._update_invoice_line_ids()
 
     @api.onchange('tax_icms_st_id')
     def _onchange_tax_icms_st_id(self):
         if self.tax_icms_st_id:
             self.icms_st_aliquota = self.tax_icms_st_id.amount
-            self._update_invoice_line_ids()
+        self._update_invoice_line_ids()
 
     @api.onchange('tax_icms_inter_id')
     def _onchange_tax_icms_inter_id(self):
-        if self.tax_icms_inter_id:
-            self._update_invoice_line_ids()
+        self._update_invoice_line_ids()
 
     @api.onchange('tax_icms_intra_id')
     def _onchange_tax_icms_intra_id(self):
-        if self.tax_icms_intra_id:
-            self._update_invoice_line_ids()
+        self._update_invoice_line_ids()
 
     @api.onchange('tax_icms_fcp_id')
     def _onchange_tax_icms_fcp_id(self):
-        if self.tax_icms_fcp_id:
-            self._update_invoice_line_ids()
+        self._update_invoice_line_ids()
 
     @api.onchange('tax_simples_id')
     def _onchange_tax_simples_id(self):
-        if self.tax_simples_id:
-            self._update_invoice_line_ids()
+        self._update_invoice_line_ids()
 
     @api.onchange('tax_pis_id')
     def _onchange_tax_pis_id(self):
         if self.tax_pis_id:
             self.pis_aliquota = self.tax_pis_id.amount
-            self._update_invoice_line_ids()
+        self._update_invoice_line_ids()
 
     @api.onchange('tax_cofins_id')
     def _onchange_tax_cofins_id(self):
         if self.tax_cofins_id:
             self.cofins_aliquota = self.tax_cofins_id.amount
-            self._update_invoice_line_ids()
+        self._update_invoice_line_ids()
 
     @api.onchange('tax_ipi_id')
     def _onchange_tax_ipi_id(self):
         if self.tax_ipi_id:
             self.ipi_aliquota = self.tax_ipi_id.amount
-            self._update_invoice_line_ids()
+        self._update_invoice_line_ids()
 
     @api.onchange('tax_ii_id')
     def _onchange_tax_ii_id(self):
         if self.tax_ii_id:
             self.ii_aliquota = self.tax_ii_id.amount
-            self._update_invoice_line_ids()
+        self._update_invoice_line_ids()
 
     @api.onchange('tax_issqn_id')
     def _onchange_tax_issqn_id(self):
         if self.tax_issqn_id:
             self.issqn_aliquota = self.tax_issqn_id.amount
-            self._update_invoice_line_ids()
+        self._update_invoice_line_ids()

--- a/br_account/models/account_tax.py
+++ b/br_account/models/account_tax.py
@@ -175,6 +175,14 @@ class AccountTax(models.Model):
             base_icmsst += self.env.context["outras_despesas"]
 
         base_icmsst *= 1 - (reducao_icmsst / 100.0)  # Redução
+
+        deducao_st_simples = 0.0
+        if "icms_st_aliquota_deducao" in self.env.context:
+            deducao_st_simples = self.env.context["icms_st_aliquota_deducao"]
+
+        if deducao_st_simples:
+            icms_value = base_icmsst * (deducao_st_simples / 100.0)
+
         base_icmsst *= 1 + aliquota_mva / 100.0  # Aplica MVA
 
         icmsst = round(

--- a/br_account/views/account_fiscal_position_view.xml
+++ b/br_account/views/account_fiscal_position_view.xml
@@ -36,6 +36,7 @@
                         <field name="icms_aliquota_credito" attrs="{'invisible': [('domain', '!=', 'simples')]}" />
                         <field name="reducao_icms" attrs="{'invisible': [('cst_icms', 'not in', ('20', '70', '90'))]}" />
                         <field name="aliquota_mva" attrs="{'invisible': [('cst_icms', 'not in', ('10', '30', '70', '90')), ('csosn_icms', 'not in', ('201', '202', '203', '900'))]}" />
+                        <field name="icms_st_aliquota_deducao" attrs="{'invisible': [('csosn_icms', 'not in', ('201', '202', '203', '900'))]}" />
                         <field name="tax_icms_inter_id" attrs="{'invisible': [('tem_difal', '=', False)]}" />
                         <field name="tax_icms_fcp_id" attrs="{'invisible': ['|', ('tem_difal', '=', False), ('domain', '=', 'simples')]}" />
                     </group>

--- a/br_account/views/account_invoice_view.xml
+++ b/br_account/views/account_invoice_view.xml
@@ -223,6 +223,7 @@
                                     <field name="icms_st_aliquota_reducao_base"/>
                                     <field name="tax_icms_st_id" />
                                     <field name="icms_st_aliquota" invisible="1"/>
+                                    <field name="icms_st_aliquota_deducao" attrs="{'invisible': [('company_fiscal_type', '==', '3')] }" />
                                     <field name="icms_st_valor"/>
                                 </group>
                                 <group name="icms_interestaual" attrs="{'invisible': [('tem_difal', '==', False)] }">

--- a/br_sale/models/sale.py
+++ b/br_sale/models/sale.py
@@ -48,13 +48,14 @@ class SaleOrderLine(models.Model):
             'icms_aliquota_reducao_base': self.icms_aliquota_reducao_base,
             'icms_st_aliquota_reducao_base':
             self.icms_st_aliquota_reducao_base,
-            'ipi_reducao_bc': self.ipi_reducao_bc
+            'ipi_reducao_bc': self.ipi_reducao_bc,
+            'icms_st_aliquota_deducao': self.icms_st_aliquota_deducao,
         }
 
     @api.depends('product_uom_qty', 'discount', 'price_unit', 'tax_id',
                  'icms_st_aliquota_mva', 'incluir_ipi_base',
                  'icms_aliquota_reducao_base', 'icms_st_aliquota_reducao_base',
-                 'ipi_reducao_bc')
+                 'ipi_reducao_bc', 'icms_st_aliquota_deducao')
     def _compute_amount(self):
         for line in self:
             price = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
@@ -78,7 +79,8 @@ class SaleOrderLine(models.Model):
 
     @api.depends('cfop_id', 'icms_st_aliquota_mva', 'aliquota_icms_proprio',
                  'incluir_ipi_base', 'icms_aliquota_reducao_base', 'tem_difal',
-                 'icms_st_aliquota_reducao_base', 'ipi_reducao_bc')
+                 'icms_st_aliquota_reducao_base', 'ipi_reducao_bc',
+                 'icms_st_aliquota_deducao')
     def _compute_detalhes(self):
         for line in self:
             msg = []
@@ -128,6 +130,10 @@ class SaleOrderLine(models.Model):
         string=u'Redução Base ICMS (%)', digits=dp.get_precision('Account'))
     icms_st_aliquota_reducao_base = fields.Float(
         string=u'Redução Base ICMS ST(%)', digits=dp.get_precision('Account'))
+    icms_st_aliquota_deducao = fields.Float(
+        string=u"% Dedução", help="Alíquota interna ou interestadual aplicada \
+         sobre o valor da operação para deduzir do ICMS ST - Para empresas \
+         do Simples Nacional", digits=dp.get_precision('Account'))
     tem_difal = fields.Boolean(string="Possui Difal")
 
     ipi_cst = fields.Char(string='CST IPI', size=5)
@@ -263,6 +269,7 @@ class SaleOrderLine(models.Model):
         res['icms_aliquota_reducao_base'] = self.icms_aliquota_reducao_base
         res['icms_st_aliquota_reducao_base'] = \
             self.icms_st_aliquota_reducao_base
+        res['icms_st_aliquota_deducao'] = self.icms_st_aliquota_deducao
         res['tem_difal'] = self.tem_difal
         res['icms_uf_remet'] = icms_inter.amount or 0.0
         res['icms_uf_dest'] = icms_intra.amount or 0.0

--- a/br_sale/views/sale_view.xml
+++ b/br_sale/views/sale_view.xml
@@ -21,6 +21,7 @@
                 <field name="aliquota_icms_proprio" invisible="1" />
                 <field name="icms_aliquota_reducao_base" invisible="1" />
                 <field name="icms_st_aliquota_reducao_base" invisible="1" />
+                <field name="icms_st_aliquota_deducao" invisible="1" />
                 <field name="ipi_cst" invisible="1" />
                 <field name="ipi_reducao_bc" invisible="1" />
                 <field name="pis_cst" invisible="1" />
@@ -42,6 +43,7 @@
                 <field name="aliquota_icms_proprio" invisible="1" />
                 <field name="icms_aliquota_reducao_base" invisible="1" />
                 <field name="icms_st_aliquota_reducao_base" invisible="1" />
+                <field name="icms_st_aliquota_deducao" invisible="1" />
                 <field name="ipi_cst" invisible="1" />
                 <field name="ipi_reducao_bc" invisible="1" />
                 <field name="pis_cst" invisible="1" />


### PR DESCRIPTION
Ao emitir nota do simples nacional quando com ST o cálculo segue a seguinte fórmula:
(Base * MVA * Aliquota ST) - (Base * Aliquota Interna ou Interestadual)