### PR TITLE
Validação da numeração da nota de entrada

### DIFF
--- a/br_account/models/account_invoice.py
+++ b/br_account/models/account_invoice.py
@@ -181,6 +181,12 @@ class AccountInvoice(models.Model):
         digits=dp.get_precision('Account'),
         compute='_compute_amount')
 
+    @api.onchange('issuer')
+    def _onchange_issuer(self):
+        if self.issuer == '0' and self.type in (u'in_invoice', u'in_refund'):
+            self.fiscal_document_id = None
+            self.document_serie_id = None
+
     @api.onchange('fiscal_document_id')
     def _onchange_fiscal_document_id(self):
         series = self.env['br_account.document.serie'].search(

--- a/br_account_einvoice/models/account_invoice.py
+++ b/br_account_einvoice/models/account_invoice.py
@@ -60,14 +60,15 @@ class AccountInvoice(models.Model):
     @api.multi
     def action_number(self):
         for invoice in self:
-            if not invoice.document_serie_id.internal_sequence_id.id:
-                raise UserError(
-                    u'Configure a sequência para a numeração da nota')
-            seq_number = \
-                invoice.document_serie_id.internal_sequence_id.next_by_id()
+            if invoice.is_eletronic:
+                if not invoice.document_serie_id.internal_sequence_id.id:
+                    raise UserError(
+                        u'Configure a sequência para a numeração da nota')
 
-            self.write(
-                {'internal_number': seq_number})
+                seq_number = \
+                    invoice.document_serie_id.internal_sequence_id.next_by_id()
+                self.write(
+                    {'internal_number': seq_number})
         return True
 
     def _prepare_edoc_item_vals(self, line):


### PR DESCRIPTION
Quando nota de entrada emissão terceiros seta o documento fiscal para None
Nota de entrada deve validar a numeração do fornecedor