### PR TITLE
Documentos eletronicos cancelados ou já emitidos não deixa excluir de…

### DIFF
--- a/br_account_einvoice/models/account_invoice.py
+++ b/br_account_einvoice/models/account_invoice.py
@@ -199,5 +199,6 @@ class AccountInvoice(models.Model):
                 if edoc.state == 'done':
                     raise UserError(u'Documento eletrônico emitido - Cancele o \
                                     documento para poder cancelar a fatura')
-                edoc.unlink()
+                if edoc.state != 'cancel':
+                    edoc.unlink()
         return res

--- a/br_account_einvoice/models/invoice_eletronic.py
+++ b/br_account_einvoice/models/invoice_eletronic.py
@@ -331,7 +331,7 @@ class InvoiceEletronic(models.Model):
     @api.multi
     def unlink(self):
         for item in self:
-            if item.state == 'done':
+            if item.state in ('done', 'cancel'):
                 raise UserError(
                     u'Documento Eletrônico enviado - Proibido excluir')
         super(InvoiceEletronic, self).unlink()

--- a/br_nfe/reports/danfe_report.xml
+++ b/br_nfe/reports/danfe_report.xml
@@ -24,9 +24,19 @@
 
     <template id="template_br_nfe_danfe">
         <div class="page">
-            <t t-if="o.ambiente == 'homologacao' or o.state != 'done'">
+            <t t-if="o.ambiente == 'homologacao'">
                 <div style="width:100%;position:fixed;top:400px;">
                   <div  style="width:64%; margin: 0 auto; font-size:60px; color:red; ">Sem Valor Fiscal</div>
+                </div>
+            </t>
+            <t t-if="o.state in ('cancel')">
+                <div style="width:100%;position:fixed;top:500px;">
+                  <div  style="width:64%; margin: 0 auto; font-size:60px; color:red; ">Nota Cancelada</div>
+                </div>
+            </t>
+            <t t-if="o.state not in ('done', 'cancel')">
+                <div style="width:100%;position:fixed;top:650px;">
+                  <div  style="width:84%; margin: 0 auto; font-size:48px; color:red;">Impresso para simples conferência</div>
                 </div>
             </t>
 
@@ -144,8 +154,13 @@
                     </div>
                     <div class="bt br bb col-xs-5 line">
                         <span class="small">Protocolo de autorização de uso</span><br />
-                        <span t-field="o.protocolo_nfe"></span> |
-                        <span t-field="o.data_autorizacao"></span><br />
+                        <t t-if="o.state in ('done', 'cancel')">
+                            <span t-field="o.protocolo_nfe"></span> |
+                            <span t-field="o.data_autorizacao"></span><br />
+                        </t>
+                        <t t-if="o.state not in ('done', 'cancel')">
+                            <span>Informações ainda não transmitidas a nenhuma SEFAZ</span>
+                        </t>
                     </div>
                 </div>
                 <div class="row line">


### PR DESCRIPTION
… maneira nenhuma

Para cancelar a fatura é obrigatório cancelar o documento eletronico antes
Danfe agora possui indicação que a nfe foi cancelada ou ainda não foi enviada