### PR TITLE
Evita usar o name da fatura como name no lançamento do diário

### DIFF
--- a/br_account/models/account_invoice.py
+++ b/br_account/models/account_invoice.py
@@ -211,7 +211,8 @@ class AccountInvoice(models.Model):
         for invoice_line in res:
             line = invoice_line[2]
             line['ref'] = self.origin
-            if line['name'] == '/':
+            if line['name'] == '/' or (
+               line['name'] == self.name and self.name):
                 line['name'] = "%02d" % count
                 count += 1
         return res


### PR DESCRIPTION
Esse campo é copiado da cotação para a fatura e ele é usado como a referencia do cliente,
não deveria ser usado na linha dos lançamentos de diário