### PR TITLE
Campos de país, estado e cidade desabilita a criação rápida

### DIFF
--- a/br_account/views/account_invoice_view.xml
+++ b/br_account/views/account_invoice_view.xml
@@ -75,7 +75,7 @@
                                 <field name="serie" attrs="{'required': [('document_type', 'in', ('nf', 'nfrural', 'cf'))]}"/>
                                 <field name="internal_number" attrs="{'required': [('document_type', 'in', ('nf', 'nfrural', 'cf'))]}"/>
                                 <field name="fiscal_document_id" attrs="{'required': [('document_type', 'in', ('nf', 'nfrural', 'cf'))]}"/>
-                                <field name="state_id" attrs="{'required': [('document_type', 'in', ('nf', 'nfrural'))], 'invisible': [('document_type', '=', 'cf')]}"/>
+                                <field name="state_id" attrs="{'required': [('document_type', 'in', ('nf', 'nfrural'))], 'invisible': [('document_type', '=', 'cf')]}" options="{'no_create': True, 'no_create_edit': True}" />
                                 <field name="date" attrs="{'required': [('document_type', 'in', ('nf', 'nfrural'))], 'invisible': [('document_type', '=', 'cf')]}"/>
                                 <field name="cpfcnpj_type" attrs="{'required': [('document_type', 'in', ('nfrural'))], 'invisible': [('document_type', '!=', 'nfrural')]}"/>
                                 <field name="cnpj_cpf" attrs="{'required': [('document_type', 'in', ('nf', 'nfrural'))], 'invisible': [('document_type', '=', 'cf')]}"/>
@@ -343,7 +343,7 @@
                                         <field name="name"/>
                                         <field name="date_registration"/>
                                         <field name="location"/>
-                                        <field name="state_id"/>
+                                        <field name="state_id" options="{'no_create': True, 'no_create_edit': True}"/>
                                         <field name="date_release"/>
                                         <field name="type_transportation"/>
                                     </tree>
@@ -352,7 +352,7 @@
                                             <group>
                                                 <field name="name"/>
                                                 <field name="date_registration"/>
-                                                <field name="state_id"/>
+                                                <field name="state_id" options="{'no_create': True, 'no_create_edit': True}"/>
                                                 <field name="location"/>
                                                 <field name="date_release"/>
                                                 <field name="type_transportation" />
@@ -361,7 +361,7 @@
                                                 <field name="afrmm_value" />
                                                 <field name="type_import" />
                                                 <field name="thirdparty_cnpj" />
-                                                <field name="thirdparty_state_id"/>
+                                                <field name="thirdparty_state_id" options="{'no_create': True, 'no_create_edit': True}"/>
                                                 <field name="exporting_code"/>
                                             </group>
                                             <group string="Adições" colspan="4">

--- a/br_base/views/res_bank_view.xml
+++ b/br_base/views/res_bank_view.xml
@@ -14,9 +14,9 @@
                    <field name="number" placeholder="Número"/>
                    <field name="street2" placeholder="Complemento"/>
                    <field name="district" placeholder="Bairro"/>
-                   <field name="country_id" placeholder="País"/>
-                   <field name="state_id" placeholder="Estado"/>
-                   <field name="city_id" placeholder="Cidade"/>
+                   <field name="country_id" placeholder="País" options="{'no_create': True, 'no_create_edit': True}" />
+                   <field name="state_id" placeholder="Estado" options="{'no_create': True, 'no_create_edit': True}" />
+                   <field name="city_id" placeholder="Cidade" options="{'no_create': True, 'no_create_edit': True}" />
                </field>
                <field name="state_id" position="attributes">
                    <attribute name="domain">[('country_id','=',country_id)]</attribute>

--- a/br_base/views/res_company_view.xml
+++ b/br_base/views/res_company_view.xml
@@ -22,13 +22,15 @@
             </field>
             <field name="state_id" position="attributes">
                 <attribute name="domain">[('country_id','=',country_id)]</attribute>
+                <attribute name="options">{'no_create': True, 'no_create_edit': True}</attribute>
             </field>
             <field name="country_id" position="replace"/>
             <field name="state_id" position="before">
-                <field name="country_id" placeholder="País" class="o_address_country" />
+                <field name="country_id" placeholder="País" class="o_address_country"
+                    options="{'no_create': True, 'no_create_edit': True}" />
             </field>
             <field name="state_id" position="after">
-                <field name="city_id" placeholder="Cidade"/>
+                <field name="city_id" placeholder="Cidade" options="{'no_create': True, 'no_create_edit': True}"/>
             </field>
             <field name="city" position="replace">
                 <field name="city" invisible="1"/>

--- a/br_base/views/res_partner_view.xml
+++ b/br_base/views/res_partner_view.xml
@@ -56,16 +56,19 @@
             </field>
             <field name="state_id" position="attributes">
                 <attribute name="domain">[('country_id','=',country_id)]</attribute>
+                <attribute name="options">{'no_create': True, 'no_create_edit': True}</attribute>
             </field>
             <field name="state_id" position="after">
-                <field name="city_id" class="o_address_city" placeholder="Cidade" />
+                <field name="city_id" class="o_address_city" placeholder="Cidade"
+                    options="{'no_create': True, 'no_create_edit': True}" />
             </field>
             <field name="city" position="replace">
                 <field name="city" invisible="1" />
             </field>
             <field name="country_id" position="replace" />
             <field name="state_id" position="before">
-                <field name="country_id" placeholder="País" class="o_address_country" />
+                <field name="country_id" placeholder="País" class="o_address_country"
+                    options="{'no_create': True, 'no_create_edit': True}" />
             </field>
             <notebook position="inside">
                 <page string="Dados Fiscais">

--- a/br_crm/views/crm_lead_view.xml
+++ b/br_crm/views/crm_lead_view.xml
@@ -22,13 +22,14 @@
             </field>
             <field name="state_id" position="attributes">
                 <attribute name="domain">[('country_id','=',country_id)]</attribute>
+                <attribute name="options">{'no_create': True, 'no_create_edit': True}</attribute>
             </field>
             <field name="state_id" position="after">
-                <field name="city_id" class="o_address_country" placeholder="Cidade" />
+                <field name="city_id" class="o_address_country" placeholder="Cidade" options="{'no_create': True, 'no_create_edit': True}"/>
             </field>
             <field name="country_id" position="replace" />
             <field name="state_id" position="before">
-                <field name="country_id" placeholder="País" class="o_address_country" />
+                <field name="country_id" placeholder="País" class="o_address_country" options="{'no_create': True, 'no_create_edit': True}" />
             </field>
 
             <field name="type" position="after">

--- a/br_crm/views/crm_opportunity_view.xml
+++ b/br_crm/views/crm_opportunity_view.xml
@@ -22,13 +22,14 @@
             </field>
             <field name="state_id" position="attributes">
                 <attribute name="domain">[('country_id','=',country_id)]</attribute>
+                <attribute name="options">{'no_create': True, 'no_create_edit': True}</attribute>
             </field>
             <field name="state_id" position="after">
-                <field name="city_id" class="o_address_country" placeholder="Cidade" />
+                <field name="city_id" class="o_address_country" placeholder="Cidade" options="{'no_create': True, 'no_create_edit': True}"/>
             </field>
             <field name="country_id" position="replace" />
             <field name="state_id" position="before">
-                <field name="country_id" placeholder="País" class="o_address_country" />
+                <field name="country_id" placeholder="País" class="o_address_country" options="{'no_create': True, 'no_create_edit': True}"/>
             </field>
 
             <field name="partner_name" position="after">

--- a/br_nfe/views/invoice_eletronic.xml
+++ b/br_nfe/views/invoice_eletronic.xml
@@ -52,7 +52,7 @@
                 <page name="exportacao" string="Exportação/Compras" attrs="{'invisible': [('model', 'not in', ('55', '65'))]}">
                     <group>
                         <group string="Exportação">
-                            <field name="uf_saida_pais_id" />
+                            <field name="uf_saida_pais_id" options="{'no_create': True, 'no_create_edit': True}" />
                             <field name="local_embarque" />
                             <field name="local_despacho" />
                         </group>

--- a/br_nfe/views/invoice_eletronic_item.xml
+++ b/br_nfe/views/invoice_eletronic_item.xml
@@ -33,7 +33,7 @@
                             <field name="name"/>
                             <field name="date_registration"/>
                             <field name="location"/>
-                            <field name="state_id"/>
+                            <field name="state_id" options="{'no_create': True, 'no_create_edit': True}"/>
                             <field name="date_release"/>
                             <field name="type_transportation"/>
                         </tree>
@@ -42,7 +42,7 @@
                                 <group>
                                     <field name="name"/>
                                     <field name="date_registration"/>
-                                    <field name="state_id"/>
+                                    <field name="state_id" options="{'no_create': True, 'no_create_edit': True}"/>
                                     <field name="location"/>
                                     <field name="date_release"/>
                                     <field name="type_transportation" />
@@ -51,7 +51,7 @@
                                     <field name="afrmm_value" />
                                     <field name="type_import" />
                                     <field name="thirdparty_cnpj" />
-                                    <field name="thirdparty_state_id"/>
+                                    <field name="thirdparty_state_id" options="{'no_create': True, 'no_create_edit': True}"/>
                                     <field name="exporting_code"/>
                                 </group>
                                 <group string="Adições" colspan="4">

--- a/br_stock_account/views/account_invoice.xml
+++ b/br_stock_account/views/account_invoice.xml
@@ -22,10 +22,10 @@
                             <field name="freight_responsibility"/>
                             <field name="carrier_id"/>
                             <field name="vehicle_plate"/>
-                            <field name="vehicle_state_id"/>
+                            <field name="vehicle_state_id" options="{'no_create': True, 'no_create_edit': True}"/>
                             <field name="vehicle_rntc"/>
                             <field name="tow_plate"/>
-                            <field name="tow_state_id"/>
+                            <field name="tow_state_id" options="{'no_create': True, 'no_create_edit': True}"/>
                             <field name="tow_rntc"/>
                         </group>
                         <group name="package_info" string="Volume">
@@ -39,7 +39,7 @@
                     </group>
                     <group>
                         <group name="exporta" string="Exportação">
-                            <field name="uf_saida_pais_id"/>
+                            <field name="uf_saida_pais_id" options="{'no_create': True, 'no_create_edit': True}"/>
                             <field name="local_embarque"/>
                             <field name="local_despacho"/>
                         </group>
@@ -74,10 +74,10 @@
                             <field name="freight_responsibility"/>
                             <field name="carrier_id"/>
                             <field name="vehicle_plate"/>
-                            <field name="vehicle_state_id"/>
+                            <field name="vehicle_state_id" options="{'no_create': True, 'no_create_edit': True}"/>
                             <field name="vehicle_rntc"/>
                             <field name="tow_plate"/>
-                            <field name="tow_state_id"/>
+                            <field name="tow_state_id" options="{'no_create': True, 'no_create_edit': True}"/>
                             <field name="tow_rntc"/>
                         </group>
                         <group name="package_info" string="Volume">


### PR DESCRIPTION
Isto evita que o cliente cadastre um registro duplicado, já que todas cidades e países já estão cadastrados