### PR TITLE
FIX - Test unitário quebra quando usado em conjunto com sales margin

### DIFF
--- a/br_sale/tests/test_br_sale.py
+++ b/br_sale/tests/test_br_sale.py
@@ -176,6 +176,7 @@ class TestSaleOrder(TransactionCase):
             (0, 0,
                 {
                     'product_id': self.default_product.id,
+                    'product_uom': self.default_product.uom_id.id,
                     'product_uom_qty': 10.0,
                     'name': 'product test 5',
                     'price_unit': 100.00,
@@ -191,6 +192,7 @@ class TestSaleOrder(TransactionCase):
             (0, 0,
                 {
                     'product_id': self.service.id,
+                    'product_uom': self.service.uom_id.id,
                     'product_uom_qty': 10.0,
                     'name': 'product test 5',
                     'price_unit': 100.00,


### PR DESCRIPTION
Adição da unidade de medida padrão na criação da linha da cotação