### PR TITLE
WIP? Corrige exportação para PDF dos relatórios

### DIFF
--- a/account_cash_flow/reports/account_cash_flow.xml
+++ b/account_cash_flow/reports/account_cash_flow.xml
@@ -3,7 +3,7 @@
     <data>
 
         <template id="account_cash_flow_template_html_report">
-             <t t-call="web.html_container">
+             <t t-call="web.external_layout">
                 <t t-call="web.external_layout">
                     <script type="text/javascript" src="/account_cash_flow/static/src/js/plotly-latest.min.js"></script>
                     <h2>Gráfico</h2>
@@ -71,7 +71,7 @@
         </template>
 
         <template id="main_template_cash_flow">
-            <t t-call="web.html_container">
+            <t t-call="web.external_layout">
                 <t t-foreach="docs" t-as="o">
                     <t t-call="account_cash_flow.account_cash_flow_template_html_report" />
                 </t>

--- a/br_nfe/reports/danfe_report.xml
+++ b/br_nfe/reports/danfe_report.xml
@@ -638,7 +638,7 @@
 
 
     <template id="main_template_br_nfe_danfe">
-        <t t-call="web.html_container">
+        <t t-call="web.external_layout">
             <t t-foreach="docs" t-as="o">
                 <t t-call="br_nfe.template_br_nfe_danfe" t-lang="o.partner_id.lang"/>
             </t>

--- a/br_nfse/reports/danfse_ginfes.xml
+++ b/br_nfse/reports/danfse_ginfes.xml
@@ -466,7 +466,7 @@
     </template>
 
     <template id="main_template_br_nfse_danfe_ginfes">
-        <t t-call="web.html_container">
+        <t t-call="web.external_layout">
             <t t-foreach="docs" t-as="doc">
                 <t t-call="br_nfse.danfse_report_template_ginfes" t-lang="doc.partner_id.lang"/>
             </t>

--- a/br_nfse/reports/danfse_imperial.xml
+++ b/br_nfse/reports/danfse_imperial.xml
@@ -330,7 +330,7 @@
     </template>
 
     <template id="main_template_br_nfse_danfe_imperial">
-        <t t-call="web.html_container">
+        <t t-call="web.external_layout">
             <t t-foreach="docs" t-as="doc">
                 <t t-call="br_nfse.danfse_report_template_imperial" t-lang="doc.partner_id.lang"/>
             </t>

--- a/br_nfse/reports/danfse_sao_paulo.xml
+++ b/br_nfse/reports/danfse_sao_paulo.xml
@@ -340,7 +340,7 @@
     </template>
 
     <template id="main_template_br_nfse_danfe">
-        <t t-call="web.html_container">
+        <t t-call="web.external_layout">
             <t t-foreach="docs" t-as="doc">
                 <t t-call="br_nfse.danfse_report_template" t-lang="doc.partner_id.lang"/>
             </t>

--- a/br_nfse/reports/danfse_simpliss.xml
+++ b/br_nfse/reports/danfse_simpliss.xml
@@ -398,7 +398,7 @@
     </template>
 
     <template id="main_template_br_nfse_danfe_simpliss">
-        <t t-call="web.html_container">
+        <t t-call="web.external_layout">
             <t t-foreach="docs" t-as="doc">
                 <t t-call="br_nfse.danfse_report_template_simpliss" t-lang="doc.partner_id.lang"/>
             </t>


### PR DESCRIPTION
Desde o commit [b446930dc42 do odoo](https://github.com/odoo/odoo/commit/b446930dc42479f524eab7e677c5b2007f9fa0a6), relatórios que usam como base o template `web.html_container` resultam em um documento vazio quando exportados para PDF, por causa [dessa linha](https://github.com/odoo/odoo/commit/b446930dc42479f524eab7e677c5b2007f9fa0a6#diff-a48de36bdafe346387b4eb7347aa2144L375) que filtra os nodes do documento.

Relatórios que usam o template `web.external_layout` são exportados para PDF corretamente.