### PR TITLE
[FIX] - Adicionado validação para emissão em nome de pessoa física

### DIFF
--- a/br_nfse_paulistana/models/invoice_eletronic.py
+++ b/br_nfse_paulistana/models/invoice_eletronic.py
@@ -121,7 +121,7 @@ class InvoiceEletronic(models.Model):
                 'tipo_cpfcnpj': 2 if partner.is_company else 1,
                 'cpf_cnpj': re.sub('[^0-9]', '',
                                    partner.cnpj_cpf or ''),
-                'razao_social': partner.legal_name if partner.legal_name else partner.name,
+                'razao_social': partner.legal_name or partner.name,
                 'logradouro': partner.street or '',
                 'numero': partner.number or '',
                 'complemento': partner.street2 or '',

--- a/br_nfse_paulistana/models/invoice_eletronic.py
+++ b/br_nfse_paulistana/models/invoice_eletronic.py
@@ -121,7 +121,7 @@ class InvoiceEletronic(models.Model):
                 'tipo_cpfcnpj': 2 if partner.is_company else 1,
                 'cpf_cnpj': re.sub('[^0-9]', '',
                                    partner.cnpj_cpf or ''),
-                'razao_social': partner.legal_name or '',
+                'razao_social': partner.legal_name if partner.legal_name else partner.name,
                 'logradouro': partner.street or '',
                 'numero': partner.number or '',
                 'complemento': partner.street2 or '',


### PR DESCRIPTION
Inicialmente não era possível enviar o nome da pessoa física para a prefeitura.
Com o fix, agora as notas saem como nome correto.

OBS: NFSE Paulistana