### PR TITLE
[FIX] Validação de CPF retornava como True valores todos iguais

### DIFF
--- a/br_base/tools/fiscal.py
+++ b/br_base/tools/fiscal.py
@@ -458,7 +458,7 @@ def validate_cpf(cpf):
     :Parameters:
       - 'cpf': CPF to be validate.
     """
-    cpf = ''.join(re.findall('\d', str(cpf)))
+    cpf = ''.join(re.findall(r'\d', str(cpf)))
 
     list_invalid = ['00000000000', '11111111111',
                     '22222222222', '33333333333',

--- a/br_base/tools/fiscal.py
+++ b/br_base/tools/fiscal.py
@@ -458,15 +458,20 @@ def validate_cpf(cpf):
     :Parameters:
       - 'cpf': CPF to be validate.
     """
-    if not cpf.isdigit():
-        cpf = re.sub('[^0-9]', '', cpf)
+    cpf = ''.join(re.findall('\d', str(cpf)))
 
-    if len(cpf) != 11:
+    list_invalid = ['00000000000', '11111111111',
+                    '22222222222', '33333333333',
+                    '44444444444', '55555555555',
+                    '66666666666', '77777777777',
+                    '88888888888', '99999999999']
+
+    if not cpf or len(cpf) != 11 or cpf in list_invalid or not cpf.isdigit():
         return False
 
-    # Pega apenas os 9 primeiros dígitos do CPF e gera os 2 dígitos
-    cpf = list(map(int, cpf))
-    novo = cpf[:9]
+    # Pega apenas os 9 primeiros dígitos do CPF e gera os 2 dígitos que faltam
+    inteiros = list(map(int, cpf))
+    novo = inteiros[:9]
 
     while len(novo) < 11:
         r = sum([(len(novo) + 1 - i) * v for i, v in enumerate(novo)]) % 11
@@ -478,7 +483,6 @@ def validate_cpf(cpf):
         novo.append(f)
 
     # Se o número gerado coincidir com o número original, é válido
-    if novo == cpf:
+    if novo == inteiros:
         return True
-
     return False


### PR DESCRIPTION
Na validação de CPF atual, retorna como "True" CPF's que possuam todos os números iguais, ex: 111.111.111-11