### PR TITLE
[FIX] Efetua arredondamento dos impostos antes de agrupar.

### DIFF
--- a/br_account/models/account_invoice.py
+++ b/br_account/models/account_invoice.py
@@ -356,7 +356,7 @@ class AccountInvoice(models.Model):
                 if key not in tax_grouped:
                     tax_grouped[key] = val
                 else:
-                    tax_grouped[key]['amount'] += val['amount']
+                    tax_grouped[key]['amount'] += round(val['amount'], 2)
                     tax_grouped[key]['base'] += val['base']
         return tax_grouped
 


### PR DESCRIPTION
Impostos e valores finais somar sempre com duas casas evita erros de arredondamento