### PR TITLE
[FIX]PR para corrigir divisões por 0

### DIFF
--- a/br_sale_stock/models/sale.py
+++ b/br_sale_stock/models/sale.py
@@ -148,5 +148,5 @@ class SaleOrderLine(models.Model):
         res['valor_seguro'] = self.valor_seguro
         res['outras_despesas'] = self.outras_despesas
         res['valor_frete'] = self.valor_frete * (round(
-            res['quantity'] / self.product_uom_qty, 2))
+            res['quantity'] / (self.product_uom_qty or 1), 2))
         return res


### PR DESCRIPTION
PR a ser analisado.
Correção de um erro quando é feita uma divisão por 0, em momentos em que é feito uma baixa de pagamento (valor fixo ou porcentagem)

==== Como reproduzir ====
Criar fatura com a opção de Baixar Pagamento selecionada e colocar qualquer valor nela.

Depois, quando é criado a opção de criar fatura com Linhas faturáveis (deduzir pagamentos baixados), ele irá criar linhas de fatura para cada linha da cotação.

Nesse momento, a divisão por 0 é feita.