### PR TITLE
[FIX] account_invoice: Corrige compute do payable_move_line_ids

### DIFF
--- a/br_account/models/account_invoice.py
+++ b/br_account/models/account_invoice.py
@@ -83,7 +83,7 @@ class AccountInvoice(models.Model):
     @api.one
     @api.depends('move_id.line_ids')
     def _compute_payables(self):
-        self.receivable_move_line_ids = self.move_id.line_ids.filtered(
+        self.payable_move_line_ids = self.move_id.line_ids.filtered(
             lambda m: m.account_id.user_type_id.type == 'payable')
 
     total_tax = fields.Float(


### PR DESCRIPTION
Seta o campo citado acima em seu compute para que as move_lines de
pagamento sejam carregadas corretamente.