### PR TITLE
[12.0] [FIX] Inclusão de TAGs para contornar rejeição 938

### DIFF
--- a/br_nfe/models/invoice_eletronic.py
+++ b/br_nfe/models/invoice_eletronic.py
@@ -411,7 +411,13 @@ class InvoiceEletronic(models.Model):
                     'pICMSST': "%.02f" % item.icms_st_aliquota,
                     'vICMSST': "%.02f" % item.icms_st_valor,
                     'pCredSN': "%.02f" % item.icms_aliquota_credito,
-                    'vCredICMSSN': "%.02f" % item.icms_valor_credito
+                    'vCredICMSSN': "%.02f" % item.icms_valor_credito,
+
+                    # TODO Implementar
+                    'vBCSTRet': '0.00',
+                    'vICMSSubstituto': '0.00',
+                    'vICMSSTRet': '0.00',
+                    'pST': '0.0000'
                 },
                 'IPI': {
                     'clEnq': item.classe_enquadramento_ipi or '',


### PR DESCRIPTION
Inclusão de TAGs para contornar rejeição 938

'vBCSTRet': '0.00',
'vICMSSubstituto': '0.00',
'vICMSSTRet': '0.00',
'pST': '0.0000'

Ainda falta implementar ;)