### PR TITLE
[11.0] [FIX] Simples Nacional Tipo 2

### DIFF
--- a/br_account/models/account_invoice_line.py
+++ b/br_account/models/account_invoice_line.py
@@ -173,7 +173,7 @@ class AccountInvoiceLine(models.Model):
     def _compute_cst_icms(self):
         for item in self:
             item.icms_cst = item.icms_cst_normal \
-                if item.company_fiscal_type == '3' else item.icms_csosn_simples
+                if item.company_fiscal_type != '1' else item.icms_csosn_simples
 
     price_tax = fields.Float(
         compute='_compute_price', string='Impostos', store=True,

--- a/br_account/views/account_invoice_view.xml
+++ b/br_account/views/account_invoice_view.xml
@@ -282,8 +282,8 @@
                         <page name="icms" string="ICMS" attrs="{'invisible': [('product_type', '=', 'service')]}">
                             <group name="detalhes_icms" string="Detalhes do ICMS">
                                 <group>
-                                    <field name="icms_cst_normal" attrs="{'invisible': [('company_fiscal_type', '!=', '3')] }" />
-                                    <field name="icms_csosn_simples" attrs="{'invisible': [('company_fiscal_type', '==', '3')] }" />
+                                    <field name="icms_cst_normal" attrs="{'invisible': [('company_fiscal_type', '==', '1')] }" />
+                                    <field name="icms_csosn_simples" attrs="{'invisible': [('company_fiscal_type', '!=', '1')] }" />
                                     <field name="icms_origem"/>
                                     <field name="icms_tipo_base" invisible="1"/>
                                     <field name="incluir_ipi_base" />


### PR DESCRIPTION
A principio empresas do tipo Simples Nacional – excesso de sublimite de receita bruta utilizam o código de tributação normal (CST) e não o CSOSN.

