### PR TITLE
Restringindo busca por modelo do documento fiscal

### DIFF
--- a/br_nfe/models/inutilized_nfe.py
+++ b/br_nfe/models/inutilized_nfe.py
@@ -62,6 +62,7 @@ class InutilizedNfe(models.Model):
             ('numero', '>=', self.numeration_start),
             ('numero', '<=', self.numeration_end),
             ('company_id', '=', self.env.user.company_id.id),
+            ('model', '=', self.modelo),
         ])
         if docs:
             errors.append('Não é possível invalidar essa série pois já existem'


### PR DESCRIPTION
Na inutilização de séries de documentos fiscais, se a empresa utilizasse mais de um modelo fiscal, era retornado erro caso as emissões de algum modelo possuíssem numeração em comum.