### PR TITLE
[IMP] br_nfe: Endereço de Entrega

### DIFF
--- a/br_nfe/models/invoice_eletronic.py
+++ b/br_nfe/models/invoice_eletronic.py
@@ -623,7 +623,9 @@ class InvoiceEletronic(models.Model):
                 'xPais': shipping_id.country_id.name,
                 'fone': re.sub('[^0-9]', '', shipping_id.phone or '')
             }
-            cnpj_cpf = re.sub('[^0-9]', '', shipping_id.cnpj_cpf or '')
+            cnpj_cpf = re.sub(
+                "[^0-9]", "", shipping_id.cnpj_cpf or partner.cnpj_cpf or ""
+            )
 
             if len(cnpj_cpf) == 14:
                 entrega.update({'CNPJ': cnpj_cpf})


### PR DESCRIPTION
Carrega CNPJ ou CPF do próprio partner principal da fatura quando estes campos não foram preenchidos no partner do endereço de entrega. 