### PR TITLE
[IMP] br_nfe: NF-e de develoção

### DIFF
--- a/br_nfe/models/account_invoice.py
+++ b/br_nfe/models/account_invoice.py
@@ -107,7 +107,7 @@ class AccountInvoice(models.Model):
         res['fatura_desconto'] = inv.total_desconto
         res['fatura_liquido'] = inv.amount_total
 
-        if inv.type != "out_refund":
+        if inv.type not in ("out_refund", "in_refund"):
             res['pedido_compra'] = inv.name
 
         res['valor_icms_uf_remet'] = inv.valor_icms_uf_remet


### PR DESCRIPTION
Melhora validação para que não seja enviada a tag de compras em
nenhuma nota de devolução. Esta alteração é necessária pois esta
tag não é aceita neste tipo de nota.