### PR TITLE
[IMP] Forma de Pagamento Padrão

### DIFF
--- a/br_nfe/models/invoice_eletronic.py
+++ b/br_nfe/models/invoice_eletronic.py
@@ -833,7 +833,7 @@ class InvoiceEletronic(models.Model):
         if len(duplicatas) > 0 and\
                 self.fiscal_position_id.finalidade_emissao not in ('2', '4'):
             vals['cobr'] = cobr
-            pag['tPag'] = '01' if pag['tPag'] == '90' else pag['tPag']
+            pag['tPag'] = '01' if pag['tPag'] == '' else pag['tPag']
             pag['vPag'] = "%.02f" % self.valor_final
 
         if self.model == '65':


### PR DESCRIPTION
**Problema:** Ao criar uma Invoice que não haja pagamento (Forma de Pagamento = 90 - Sem Pagamento) e gerar uma NFe o campo Fatura (Duplicata) da NFe é criado e preenchido com uma cobrança no valor da nota.

**Correção:** A função If está preenchendo o Tipo de Pagamento com 01 - Dinheiro sempre que a Forma de Pagamento for  90 - Sem Pagamento, sendo que era para preencher quando a Forma de Pagamento estivesse vazia ou não fosse definida.

Com esta alteração é possível emitir uma NFe "Sem Pagamento" (Ex.: NFe de Amostra) e sempre que a Forma de Pagamento não for especificada ou estiver vazia, por padrão será definidor como 01 - Dinheiro.