### PR TITLE
[IMP] l10n_br_account

### DIFF
--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -1,5 +1,5 @@
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AccountTax(models.Model):
@@ -20,3 +20,27 @@ class AccountTax(models.Model):
                                ('irrf', 'IRRF'),
                                ('inss', 'INSS'),
                                ('outros', 'Outros')], string="Tipo")
+    l10n_br_retention = fields.Boolean(string="Retenção?", compute="_compute_retention", inverse="_inverse_retention")
+
+    def compute_all(self, price_unit, currency=None, quantity=1.0, product=None, partner=None, is_refund=False, handle_price_include=True):
+        taxes = super(AccountTax, self).compute_all(
+            price_unit, currency, quantity, product, partner,
+            is_refund, handle_price_include)
+
+        return taxes
+
+    @api.depends("amount")
+    def _compute_retention(self):
+        if self.amount < 0:
+            self.l10n_br_retention = True
+        else:
+            self.l10n_br_retention = False
+
+    def _inverse_retention(self):
+        self.l10n_br_retention = self.l10n_br_retention
+
+    @api.onchange("l10n_br_retention")
+    def _onchange_retention(self):
+        if (self.l10n_br_retention and self.amount > 0 or 
+            not self.l10n_br_retention and self.amount < 0):
+            self.amount = self.amount * (-1)

--- a/l10n_br_account/views/account_tax.xml
+++ b/l10n_br_account/views/account_tax.xml
@@ -6,6 +6,9 @@
             <field name="amount_type" position="after">
                 <field name="domain" />
             </field>
+            <xpath expr="//group/group/div" position="after">
+                <field name="l10n_br_retention"></field>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
This commit intends to clarify the way that taxes retentions are made,
without break the way that already works. A new boolean field called
l10n_br_retention was added and based on it the tax amount is multiply
by -1. When the tax amount is negative, this field is set to true.