### PR TITLE
O método _prepare_invoice_line tem parametros opcionais

### DIFF
--- a/l10n_br_sale/models/sale.py
+++ b/l10n_br_sale/models/sale.py
@@ -169,8 +169,8 @@ class SaleOrderLine(models.Model):
             or self.l10n_br_is_insurance
         )
 
-    def _prepare_invoice_line(self):
-        res = super(SaleOrderLine, self)._prepare_invoice_line()
+    def _prepare_invoice_line(self, **optional_values):
+        res = super(SaleOrderLine, self)._prepare_invoice_line(**optional_values)
         res.update(
             {
                 "l10n_br_is_delivery": self.is_delivery,


### PR DESCRIPTION
Fiz um teste para emitir nota e recebi o erro a seguir

`
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 639, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 315, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: _prepare_invoice_line() got an unexpected keyword argument 'sequence'
`

Isso ocorre porque o método _prepare_invoice_line deve ser
`
def _prepare_invoice_line(self, **optional_values)
`