### PR TITLE
O total da nota deve incluir o valor do frete!

### DIFF
--- a/l10n_br_eletronic_document/models/nfe.py
+++ b/l10n_br_eletronic_document/models/nfe.py
@@ -541,8 +541,8 @@ class EletronicDocument(models.Model):
             'vPIS': "%.02f" % self.pis_valor,
             'vCOFINS': "%.02f" % self.cofins_valor,
             'vOutro': "%.02f" % self.valor_despesas,
-            'vNF': "%.02f" % sum(self.document_line_ids.mapped(
-                "valor_liquido")),
+            'vNF': "%.02f" % (sum(self.document_line_ids.mapped(
+                "valor_liquido")) + self.valor_frete),
             'vFCPUFDest': "%.02f" % self.valor_icms_fcp_uf_dest,
             'vICMSUFDest': "%.02f" % self.valor_icms_uf_dest,
             'vICMSUFRemet': "%.02f" % self.valor_icms_uf_remet,


### PR DESCRIPTION
Tentei uma transmissão da nota e deu erro que o total não batia com os itens! Verifiquei que o vNF só estava considerando os itens mas não o frete!