### PR TITLE
base_address_city dependency fix for l10n_br_base_address

### DIFF
--- a/l10n_br_base_address/__manifest__.py
+++ b/l10n_br_base_address/__manifest__.py
@@ -12,7 +12,7 @@
     'depends': [
         'account',
         'l10n_br_base',
-        'base_address_city',
+        'base_address_extended',
     ],
     'data': [
         'data/configuration.xml',

--- a/l10n_br_base_address/views/res_city.xml
+++ b/l10n_br_base_address/views/res_city.xml
@@ -2,7 +2,7 @@
   <record id="view_city_tree" model="ir.ui.view">
     <field name="name">l10n_br_base_address.view_city_tree</field>
     <field name="model">res.city</field>
-    <field name="inherit_id" ref="base_address_city.view_city_tree" />
+    <field name="inherit_id" ref="base_address_extended.view_city_tree" />
     <field name="arch" type="xml">
       <field name="zipcode" position="after">
         <field name="l10n_br_ibge_code" />


### PR DESCRIPTION
`base_address_city` addon does not exist in Oddo 16.0. The `base_address_city.view_city_tree` field was incorporated into `base_address_extended`.

Closes #1267